### PR TITLE
Improve output folder readability

### DIFF
--- a/lighthouse_runner.js
+++ b/lighthouse_runner.js
@@ -187,7 +187,7 @@ const complete = (urlList, autoOpen) => {
     };
     let fileTime = new Date().toLocaleString();
     // Replacing characters that make OS sad
-    fileTime = fileTime.replace(/ /g, '');
+    fileTime = fileTime.replace(/ /g, '__');
     fileTime = fileTime.replace(/\//g, '_');
     fileTime = fileTime.replace(/,/g, '_');
     fileTime = fileTime.replace(/:/g, "_");


### PR DESCRIPTION
Very minor change that transforms the name of the output folder into a more readable format.

Before: `2020-8-3117_22_41`
Now: `2020-8-31__17_44_43`

If this change is not wanted, feel free to drop it. Just a suggestion.